### PR TITLE
Fix issue with get_humanized_datetime when result is today

### DIFF
--- a/oncall_slackbot/integrations/pagerduty.py
+++ b/oncall_slackbot/integrations/pagerduty.py
@@ -38,13 +38,13 @@ def get_humanized_datetime(datetime_string: str, dest_time_zone_str: Optional[st
     parsed = datetime.strptime(datetime_string, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=UTC)
     if dest_time_zone_str:
         dest_time_zone = timezone(dest_time_zone_str)
-        parsed = parsed.replace(tzinfo=dest_time_zone)
+        parsed = parsed.astimezone(dest_time_zone)
     else:
         dest_time_zone = UTC
     result = humanize.naturaldate(parsed)
     if result != 'today':
         return result
-    return humanize.naturaltime(parsed - datetime.now(dest_time_zone))
+    return humanize.naturaltime(datetime.now(dest_time_zone) - parsed)
 
 
 def get_current_oncall() -> Optional[Oncall]:


### PR DESCRIPTION
- Change to use astimezone to account for DST
- When result is not `today`, the calculate value is inverted, giving a result like `19 hours ago` instead of `4 hours`